### PR TITLE
Add support for Java 9+

### DIFF
--- a/MachineConfig.cs
+++ b/MachineConfig.cs
@@ -13,13 +13,16 @@ namespace FreenetTray {
     public class MachineConfig {
 
         private static string JRERegistryKey = @"Software\\JavaSoft\\Java Runtime Environment";
+        private static string JRERegistryKey2 = @"Software\\JavaSoft\\JRE";
+        private static string[] JREKeys = {JRERegistryKey, JRERegistryKey2};
 
         private static bool Has64BitJRE {
             get {
                 RegistryKey local64 = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
-                RegistryKey jreKey64 = local64.OpenSubKey(JRERegistryKey);
-                if (jreKey64 != null) {
-                    return true;
+                foreach (var key in JREKeys)
+                {
+                    if (local64.OpenSubKey(key) != null)
+                        return true;
                 }
                 return false;
             }


### PR DESCRIPTION
Java 9 and later only support 64-bit operating systems, and move the
registry keys:

> # Windows Registry Settings
>
> The installation program for the Microsoft Windows version of the Java
> SE Runtime Environment uses the registry to store path and version
> information.
>
> It creates the following registry keys:
>
> * HKEY_LOCAL_MACHINE\Software\JavaSoft\JRE
>
>   This key contains the string CurrentVersion, with a value that is the
>   highest installed version on the system.

[0] https://docs.oracle.com/javase/9/install/installation-jdk-and-jre-microsoft-windows-platforms.htm#JSJIG-GUID-47C269A3-5220-412F-9E31-4B8C37A82BFB
[1] https://docs.oracle.com/javase/10/install/installation-jdk-and-jre-microsoft-windows-platforms.htm#JSJIG-GUID-47C269A3-5220-412F-9E31-4B8C37A82BFB