### PR TITLE
IE related crash, Edge support, wrapper.log in standart editor

### DIFF
--- a/Browsers/Browser.cs
+++ b/Browsers/Browser.cs
@@ -71,7 +71,7 @@ namespace FreenetTray.Browsers {
             return _path;
         }
 
-        public bool Open(Uri target) {
+        public virtual bool Open(Uri target) {
             if (!IsAvailable()) {
                 return false;
             }

--- a/Browsers/BrowserUtil.cs
+++ b/Browsers/BrowserUtil.cs
@@ -15,7 +15,7 @@ namespace FreenetTray.Browsers
             new Chrome(),
             new Firefox(),
             new Opera(),
-			// All Windows 10 systems should have Edge older systems should have Internet Explorer, so check it last.
+            // All Windows 10 systems should have Edge older systems should have Internet Explorer, so check it last.
             new Edge(),
             new InternetExplorer(),
         };

--- a/Browsers/BrowserUtil.cs
+++ b/Browsers/BrowserUtil.cs
@@ -15,7 +15,8 @@ namespace FreenetTray.Browsers
             new Chrome(),
             new Firefox(),
             new Opera(),
-            // All systems should have Internet Explorer, so check it last.
+			// All Windows 10 systems should have Edge older systems should have Internet Explorer, so check it last.
+            new Edge(),
             new InternetExplorer(),
         };
 

--- a/Browsers/Edge.cs
+++ b/Browsers/Edge.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using Microsoft.Win32;
 
@@ -37,6 +38,18 @@ namespace FreenetTray.Browsers {
             _path = Path.Combine(Environment.GetEnvironmentVariable("windir"), "explorer.exe");
 
             _name = "Edge";
+        }
+
+        public override bool Open(Uri target)
+        {
+            if (!IsAvailable())
+            {
+                return false;
+            }
+
+            // Edge needs qoutes around the argument
+            Process.Start(_path, string.Format("\"{0}\"", _args + target));
+            return true;
         }
 
     }

--- a/Browsers/InternetExplorer.cs
+++ b/Browsers/InternetExplorer.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
+using System.IO;
+using System.Linq;
 using Microsoft.Win32;
 
 namespace FreenetTray.Browsers
@@ -7,6 +9,10 @@ namespace FreenetTray.Browsers
     class InternetExplorer: Browser
     {
         private static string IERegistryKey = @"Software\Microsoft\Internet Explorer";
+        private static readonly string[] Locations = {
+                                                 @"%PROGRAMFILES%\internet explorer",
+                                                 @"%PROGRAMFILES(X86)%\internet explorer",
+                                               };
 
         public InternetExplorer()
         {
@@ -26,8 +32,12 @@ namespace FreenetTray.Browsers
                 }
             }
 
-            // TODO: Also check for existence of executable?
-            _isInstalled = _version != null;
+            _path = Locations
+                .Select(location => Environment.ExpandEnvironmentVariables(location) + @"\iexplore.exe")
+                .Where(File.Exists)
+                .FirstOrDefault();
+
+            _isInstalled = _path != null;
 
             // See https://en.wikipedia.org/wiki/Internet_Explorer_8#InPrivate
             _isUsable = _version >= new Version(8, 0);

--- a/CommandsMenu.cs
+++ b/CommandsMenu.cs
@@ -268,7 +268,7 @@ namespace FreenetTray
 
         private void ViewLogs()
         {
-			// start the standart editor
+            // start the standart editor
             Process.Start(_node.WrapperLogFilename);
         }
 

--- a/CommandsMenu.cs
+++ b/CommandsMenu.cs
@@ -268,7 +268,8 @@ namespace FreenetTray
 
         private void ViewLogs()
         {
-            Process.Start("notepad.exe", _node.WrapperLogFilename);
+			// start the standart editor
+            Process.Start(_node.WrapperLogFilename);
         }
 
         private void RefreshMenu(bool running)


### PR DESCRIPTION
Internet Explorer doesnt exists on Win10 anymore (caused crash), so added IE location check, Edge support for Win10, standart editor for log (not the native notepad.exe)