### PR TITLE
Move to .NET Framework 4.8 and set to high DPI aware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       shell: cmd
 
     - name: Build the solution
-      run: msbuild /p:Configuration=Release /p:TargetFrameworkVersion="v4.5.2" /p:DebugSymbols=False "%Solution_Name%"
+      run: msbuild /p:Configuration=Release /p:TargetFrameworkVersion="v4.8" /p:DebugSymbols=False "%Solution_Name%"
       shell: cmd
 
     - name: Sign the installer
@@ -46,7 +46,7 @@ jobs:
 
     - name: Verify the signature
       if: ${{ github.event_name != 'pull_request' }}
-      run: call "%programfiles(x86)%/Windows Kits/10/bin/10.0.17763.0/x86/signtool.exe" verify /v /pa "bin/Release/FreenetTray.exe"
+      run: call "%programfiles(x86)%/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe" verify /v /pa "bin/Release/FreenetTray.exe"
       shell: cmd
 
     - name: Upload the installer as an artifact

--- a/FreenetTray.csproj
+++ b/FreenetTray.csproj
@@ -33,7 +33,7 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/app.config
+++ b/app.config
@@ -5,7 +5,7 @@
         <section name="FreenetTray.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
     </sectionGroup>
 </configSections>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup><userSettings>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup><userSettings>
         <FreenetTray.Properties.Settings>
             <setting name="StartIcon" serializeAs="String">
                 <value>True</value>
@@ -23,8 +23,12 @@
                 <value>Off</value>
             </setting>
             <setting name="CustomLocation" serializeAs="String">
-                <value />
+                <value/>
             </setting>
         </FreenetTray.Properties.Settings>
     </userSettings>
+  <System.Windows.Forms.ApplicationConfigurationSection>
+    <add key="DpiAwareness" value="PerMonitor" />
+    <add key="DpiAwareness" value="PerMonitorV2" />
+  </System.Windows.Forms.ApplicationConfigurationSection>
 </configuration>


### PR DESCRIPTION
.NET Framework 4.8 is the latest .NET Framework Microsoft suggests to use, and also works on Windows 7. It also supports high DPI so text don't look blurry.